### PR TITLE
feat: make the validator ERC-7780 & ERC-1271 compatible

### DIFF
--- a/src/SemaphoreMSAValidator.sol
+++ b/src/SemaphoreMSAValidator.sol
@@ -322,7 +322,7 @@ contract SemaphoreMSAValidator is ERC7579ValidatorBase {
         bytes32 userOpHash
     )
         external
-        // view
+        virtual
         override
         returns (ValidationData)
     {
@@ -376,24 +376,53 @@ contract SemaphoreMSAValidator is ERC7579ValidatorBase {
         return EIP1271_SUCCESS;
     }
 
+    // For [ERC-7780](https://eips.ethereum.org/EIPS/eip-7780)
+    //  stateless validator
+    /**
+     * Validates a signature given some data
+     *
+     * @param hash The data that was signed over
+     * @param signature The signature to verify
+     * @param data The data to validate the verified signature agains
+     *
+     * MUST validate that the signature is a valid signature of the hash
+     * MUST compare the validated signature against the data provided
+     * MUST return true if the signature is valid and false otherwise
+     */
     function validateSignatureWithData(
-        bytes32,
-        bytes calldata,
-        bytes calldata
+        bytes32 hash,
+        bytes calldata signature,
+        bytes calldata data
     )
         external
         view
         virtual
-        returns (bool validSig)
+        returns (bool)
     {
         return true;
     }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                INTERNAL FUNCTIONS
+    //////////////////////////////////////////////////////////////////////////*/
 
     function _isAllowedSelector(bytes4 sel) internal view returns (bool allowed) {
         for (uint256 i = 0; i < ALLOWED_SELECTORS.length; ++i) {
             if (sel == ALLOWED_SELECTORS[i]) return true;
         }
         return false;
+    }
+
+    function _validateSignatureWithConfig(
+        address account,
+        bytes32 hash,
+        bytes calldata data
+    )
+        internal
+        view
+        returns (bool)
+    {
+        return true;
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -426,6 +455,6 @@ contract SemaphoreMSAValidator is ERC7579ValidatorBase {
      * @return true if the module is of the given type, false otherwise
      */
     function isModuleType(uint256 typeID) external pure override returns (bool) {
-        return typeID == TYPE_VALIDATOR;
+        return typeID == TYPE_VALIDATOR || typeID == TYPE_STATELESS_VALIDATOR;
     }
 }

--- a/src/utils/CurveBabyJubJub.sol
+++ b/src/utils/CurveBabyJubJub.sol
@@ -138,6 +138,7 @@ library CurveBabyJubJub {
      * @dev Helper function to call the bigModExp precompile
      */
     function expmod(uint256 _b, uint256 _e, uint256 _m) internal view returns (uint256 o) {
+        // solhint-disable-next-line no-inline-assembly
         assembly {
             let memPtr := mload(0x40)
             mstore(memPtr, 0x20) // Length of base _b

--- a/src/utils/CurveBabyJubJub.sol
+++ b/src/utils/CurveBabyJubJub.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.23 <=0.8.29;
 
 // ref: https://github.com/yondonfu/sol-baby-jubjub
-//   with: https://github.com/yondonfu/sol-baby-jubjub/pull/1
+//   with PR#1: https://github.com/yondonfu/sol-baby-jubjub/pull/1
 
 library CurveBabyJubJub {
     // Curve parameters

--- a/src/utils/Identity.sol
+++ b/src/utils/Identity.sol
@@ -3,8 +3,8 @@ pragma solidity >=0.8.23 <=0.8.29;
 
 import { PoseidonT3 } from "poseidon-solidity/PoseidonT3.sol";
 import { PoseidonT6 } from "poseidon-solidity/PoseidonT6.sol";
-import { LibString } from "solady/Milady.sol";
 import { CurveBabyJubJub } from "./CurveBabyJubJub.sol";
+// import { LibString } from "solady/Milady.sol";
 // import { Vm } from "forge-std/Vm.sol";
 // import { console } from "forge-std/console.sol";
 

--- a/src/utils/Identity.sol
+++ b/src/utils/Identity.sol
@@ -3,12 +3,10 @@ pragma solidity >=0.8.23 <=0.8.29;
 
 import { PoseidonT3 } from "poseidon-solidity/PoseidonT3.sol";
 import { PoseidonT6 } from "poseidon-solidity/PoseidonT6.sol";
-import { Vm } from "forge-std/Vm.sol";
+// import { Vm } from "forge-std/Vm.sol";
 // import { console } from "forge-std/console.sol";
 import { LibString } from "solady/Milady.sol";
 import { CurveBabyJubJub } from "./CurveBabyJubJub.sol";
-
-Vm constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
 
 library Identity {
     uint256 internal constant base8x = CurveBabyJubJub.Base8x;
@@ -19,24 +17,26 @@ library Identity {
         cmt = PoseidonT3.hash([pkX, pkY]);
     }
 
-    function verifySignatureFFI(bytes32 message, bytes memory signature) public returns (bool) {
-        (uint256 pkX, uint256 pkY, uint256 s0, uint256 s1, uint256 s2) =
-            abi.decode(signature, (uint256, uint256, uint256, uint256, uint256));
+    // function verifySignatureFFI(bytes32 message, bytes memory signature) public returns (bool) {
+    //     (uint256 pkX, uint256 pkY, uint256 s0, uint256 s1, uint256 s2) =
+    //         abi.decode(signature, (uint256, uint256, uint256, uint256, uint256));
 
-        string[] memory inputs = new string[](6);
-        inputs[0] = "pnpm";
-        inputs[1] = "semaphore-identity";
-        inputs[2] = "verify";
-        inputs[3] = vm.toString(abi.encodePacked(pkX, pkY));
-        inputs[4] = vm.toString(message);
-        inputs[5] = vm.toString(abi.encodePacked(s0, s1, s2));
+    //     Vm constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
 
-        bytes memory res = vm.ffi(inputs);
-        string memory resStr = string(res);
-        return LibString.eq(resStr, "true");
-    }
+    //     string[] memory inputs = new string[](6);
+    //     inputs[0] = "pnpm";
+    //     inputs[1] = "semaphore-identity";
+    //     inputs[2] = "verify";
+    //     inputs[3] = vm.toString(abi.encodePacked(pkX, pkY));
+    //     inputs[4] = vm.toString(message);
+    //     inputs[5] = vm.toString(abi.encodePacked(s0, s1, s2));
 
-    function verifySignature(bytes32 message, bytes memory signature) public returns (bool) {
+    //     bytes memory res = vm.ffi(inputs);
+    //     string memory resStr = string(res);
+    //     return LibString.eq(resStr, "true");
+    // }
+
+    function verifySignature(bytes32 message, bytes memory signature) public view returns (bool) {
         // Implement eddsa-poseidon verifySignature() method in solidity.
         // https://github.com/privacy-scaling-explorations/zk-kit/blob/388f72b7a029a14bf5c20861d5f54bdaa98b3ac7/packages/eddsa-poseidon/src/eddsa-poseidon-factory.ts#L127-L158
         (uint256 pkX, uint256 pkY, uint256 s0, uint256 s1, uint256 s2) =
@@ -44,22 +44,16 @@ library Identity {
 
         uint256 hm = PoseidonT6.hash([s0, s1, pkX, pkY, uint256(message)]);
 
-        // TODO: remove this after you can increase gas limit in getExecOps()
-        vm.pauseGasMetering();
-
         (uint256 pLeftx, uint256 pLefty) = CurveBabyJubJub.pointMul(base8x, base8y, s2);
 
         // This is suppose to be: CurveBabyJubJub.pointMul(pkX, pkY, mulmod(8, hm, FM)),
-        //   but I'm not sure the field modulus to use. No, not `CurveBabyJubJub.Q`.
+        //   but I'm not sure the field modulo to use. No, not `CurveBabyJubJub.Q`.
         (uint256 pRightx, uint256 pRighty) = CurveBabyJubJub.pointMul(pkX, pkY, hm);
         (pRightx, pRighty) = CurveBabyJubJub.pointAdd(pRightx, pRighty, pRightx, pRighty);
         (pRightx, pRighty) = CurveBabyJubJub.pointAdd(pRightx, pRighty, pRightx, pRighty);
         (pRightx, pRighty) = CurveBabyJubJub.pointAdd(pRightx, pRighty, pRightx, pRighty);
 
         (uint256 pSumx, uint256 pSumy) = CurveBabyJubJub.pointAdd(s0, s1, pRightx, pRighty);
-
-        // TODO: remove this after you can increase gas limit in getExecOps()
-        vm.resumeGasMetering();
 
         return (pLeftx == pSumx && pLefty == pSumy);
     }

--- a/src/utils/Identity.sol
+++ b/src/utils/Identity.sol
@@ -3,10 +3,10 @@ pragma solidity >=0.8.23 <=0.8.29;
 
 import { PoseidonT3 } from "poseidon-solidity/PoseidonT3.sol";
 import { PoseidonT6 } from "poseidon-solidity/PoseidonT6.sol";
-// import { Vm } from "forge-std/Vm.sol";
-// import { console } from "forge-std/console.sol";
 import { LibString } from "solady/Milady.sol";
 import { CurveBabyJubJub } from "./CurveBabyJubJub.sol";
+// import { Vm } from "forge-std/Vm.sol";
+// import { console } from "forge-std/console.sol";
 
 library Identity {
     uint256 internal constant base8x = CurveBabyJubJub.Base8x;

--- a/test/Identity.t.sol
+++ b/test/Identity.t.sol
@@ -20,7 +20,7 @@ contract IdentityTest is Test {
         assertEq(true, IdentityT.verifySignature(hash, signature));
     }
 
-    function test_verifySignatureAcceptCorrectSignature2() public {
+    function test_verifySignatureAcceptCorrectSignature2() public view {
         bytes32 hash = hex"00b917632b69261f21d20e0cabdf9f3fa1255c6e500021997a16cf3a46d80297";
         bytes memory signature =
             hex"26c3a847609100b3fd926d3c0a61324a32479d5989f01383aca537869cb23a851d67a417abb29f71e1f7c3d0bcd93cb68f89203b046174f03c3822a9139b512611b5289e52e9f70ff4a30cb9a19d66de49266887d3d17ed35f2dfc30f44573dc0c44756c4e4c5a5e5eeacc68f39b4e2238041e70ca926139ea039e260ea7ca5000b8d0dfc37fc5de7b0f80b722f8966a43caa10c8068cf863e5d06f82ae7c9d8";

--- a/test/Identity.t.sol
+++ b/test/Identity.t.sol
@@ -23,6 +23,7 @@ contract IdentityTest is Test {
     function test_verifySignatureAcceptCorrectSignature2() public view {
         bytes32 hash = hex"00b917632b69261f21d20e0cabdf9f3fa1255c6e500021997a16cf3a46d80297";
         bytes memory signature =
+        // solhint-disable-next-line max-line-length
             hex"26c3a847609100b3fd926d3c0a61324a32479d5989f01383aca537869cb23a851d67a417abb29f71e1f7c3d0bcd93cb68f89203b046174f03c3822a9139b512611b5289e52e9f70ff4a30cb9a19d66de49266887d3d17ed35f2dfc30f44573dc0c44756c4e4c5a5e5eeacc68f39b4e2238041e70ca926139ea039e260ea7ca5000b8d0dfc37fc5de7b0f80b722f8966a43caa10c8068cf863e5d06f82ae7c9d8";
 
         assertEq(true, IdentityT.verifySignature(hash, signature));

--- a/test/SemaphoreMSAValidator.t.sol
+++ b/test/SemaphoreMSAValidator.t.sol
@@ -304,11 +304,11 @@ contract SemaphoreValidatorUnitTest is RhinestoneModuleKit, Test {
             txValidator: address(semaphoreValidator)
         });
 
-        // TODO: We need to increase the accountGasLimits, default 2e6 is not enough to verify
-        //    signature, for all those elliptic curve computation.
-        // userOpData.userOp.accountGasLimits = bytes32(uint256(2e7));
-        // userOpData.userOpHash = smartAcct.aux.entrypoint.getUserOpHash(userOpData.userOp);
-
+        // We need to increase the accountGasLimits, default 2e6 is not enough to verify
+        // signature, for all those elliptic curve computation.
+        // Encoding two fields here, validation and execution gas
+        userOpData.userOp.accountGasLimits = bytes32(abi.encodePacked(uint128(2e7), uint128(2e7)));
+        userOpData.userOpHash = smartAcct.aux.entrypoint.getUserOpHash(userOpData.userOp);
         userOpData.userOp.signature = id.signHash(userOpData.userOpHash);
     }
 
@@ -486,6 +486,8 @@ contract SemaphoreValidatorUnitTest is RhinestoneModuleKit, Test {
             callData: abi.encodeCall(SimpleContract.setVal, (testVal)),
             txValidator: address(semaphoreValidator)
         });
+        userOpData.userOp.accountGasLimits = bytes32(abi.encodePacked(uint128(2e7), uint128(2e7)));
+        userOpData.userOpHash = smartAcct.aux.entrypoint.getUserOpHash(userOpData.userOp);
         userOpData.userOp.signature = member.identity.signHash(userOpData.userOpHash);
 
         smartAcct.expect4337Revert(SemaphoreMSAValidator.NonValidatorCallBanned.selector);


### PR DESCRIPTION
- Implemented **validateSignatureWithData()** making the MSA validator [ERC-7780](https://eips.ethereum.org/EIPS/eip-7780) compatible.
- Implemented **isValidSignatureWithSender()** making the MSA validator [ERC-1271](https://eips.ethereum.org/EIPS/eip-1271) compatible.